### PR TITLE
Ruby slave updates and plugins

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -3,3 +3,6 @@ ansible:0.5
 pipeline-milestone-step:1.2
 pipeline-model-api:0.7.1
 pipeline-rest-api:2.4
+envinject:1.93.1
+aws-credentials:1.16
+credentials-binding:1.10

--- a/slave-ruby/Dockerfile
+++ b/slave-ruby/Dockerfile
@@ -10,10 +10,14 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install Ruby
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake rh-ruby23-rubygem-bundler" && \
+    INSTALL_PKGS="rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake rh-ruby23-rubygem-bundler zlib-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
+
+RUN yum groupinstall -y "Development Tools"
+
+RUN scl enable rh-ruby23 "gem update --system"
 
 RUN chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME

--- a/slave-ruby/test/run
+++ b/slave-ruby/test/run
@@ -12,7 +12,9 @@ docker run ${IMAGE_NAME} oc
 # the default entrypoint for the image assumes if you supply more than
 # one arg, you are trying to invoke the slave logic, so we have to
 # override the entrypoing to run complicated commands for testing.
-docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'gem --version'
-docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'ruby --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'gem --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'ruby --version'
+#If nokogiri can install anything can
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'gem install nokogiri -v '1.6.8.1''
 
 echo "SUCCESS!"


### PR DESCRIPTION
Changes required to use this slave to build our ruby modules and added additional plugins required for the jenkins jobs.

* Add envinject and aws-credentials plugin
* Ruby slave (slave-ruby) Dockerfile updates:
   * Add gem update --system
   * Add installation of development tools to allow for gems with native extensions
   * Install zlib-devel, required by nokogiri
   * Add --rm to docker run tests
   * Add test that installs a gem (nokogiri)

**Verification:**

```
$ docker build -t jenkins-slave-ruby-centos7 .
$ IMAGE_NAME=jenkins-slave-ruby-centos7 test/run
```
