### PR TITLE
Increase the maximum amount of memory the jenkins pod can use (2Gi).

### DIFF
--- a/jenkins-template.yml
+++ b/jenkins-template.yml
@@ -325,7 +325,7 @@ parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
   name: MEMORY_LIMIT
-  value: 512Mi
+  value: 2Gi
 - description: Volume space available for data, e.g. 512Mi, 2Gi.
   displayName: Volume Capacity
   name: VOLUME_CAPACITY


### PR DESCRIPTION
We need to allow Jenkins to use more memory by default or parallel git checkouts will crash the pod.

Jira:

https://issues.jboss.org/browse/RHMAP-13462