### PR TITLE
Allow insecure connections on jenkins route.

### DIFF
--- a/jenkins-template.yml
+++ b/jenkins-template.yml
@@ -19,7 +19,7 @@ objects:
     name: ${JENKINS_SERVICE_NAME}
   spec:
     tls:
-      insecureEdgeTerminationPolicy: Redirect
+      insecureEdgeTerminationPolicy: Allow
       termination: edge
     to:
       kind: Service


### PR DESCRIPTION
* Required for test environments where SSL is not enabled and port 443 is not enabled.