### PR TITLE
Add LimitRange to jenkins template for resource management improvements

### DIFF
--- a/jenkins-template.yml
+++ b/jenkins-template.yml
@@ -162,7 +162,7 @@ objects:
     strategy:
       dockerStrategy:
           noCache: true
-      type: Docker 
+      type: Docker
     triggers:
     - type: ImageChange
     - type: ConfigChange
@@ -339,6 +339,16 @@ objects:
       name: ${JENKINS_SERVICE_NAME}
     sessionAffinity: None
     type: ClusterIP
+- apiVersion: v1
+  kind: "LimitRange"
+  metadata:
+    name: jenkins-resource-limits
+  spec:
+    limits:
+      - type: Container
+        defaultRequest:
+          cpu: 1
+          memory: 1Gi
 parameters:
 - description: The name of the github organization to reference in the configuration
   displayName: Github Organization


### PR DESCRIPTION
**Summary**
The purpose of this change is to limit the amount of resources being consumed by Jenkins on an Openshift cluster, particularly when it is build all RHMAP components in parallel.

**Related Jira**
https://issues.jboss.org/browse/RHMAP-13829

**Validation Steps**
Can be found in related Jira ticket [comment](https://issues.jboss.org/browse/RHMAP-13829?focusedCommentId=13373036&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13373036)