### PR TITLE
Added dependencies for node-gyp to start working on slaves

### DIFF
--- a/jenkins-template.yml
+++ b/jenkins-template.yml
@@ -66,6 +66,7 @@ objects:
     strategy:
       dockerStrategy:
           noCache: true
+          forcePull: true  
       type: Docker
     triggers:
     - type: ImageChange
@@ -97,6 +98,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
+          forcePull: true  
           noCache: true
       type: Docker
     triggers:
@@ -129,6 +131,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
+          forcePull: true  
           noCache: true
       type: Docker
     triggers:
@@ -161,6 +164,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
+          forcePull: true  
           noCache: true
       type: Docker
     triggers:

--- a/slave-base-ubuntu/Dockerfile
+++ b/slave-base-ubuntu/Dockerfile
@@ -10,11 +10,21 @@ ENV HOME=/home/jenkins
 RUN apt-get update && \
     apt-get -y install software-properties-common python-software-properties && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
     apt-get update && \
-    apt-get -y install make ant bc curl wget gettext git openjdk-8-jdk lsof unzip zip && \
+    apt-get -y install gcc-4.8 make memcached ant bc curl wget gettext git openjdk-8-jdk lsof unzip zip liblog4cxx10-dev bzip2 g++-4.8 && \
     wget http://ftp.us.debian.org/debian/pool/main/n/nss-wrapper/libnss-wrapper_1.1.3-1_amd64.deb && \
     dpkg -i libnss-wrapper_1.1.3-1_amd64.deb && \
+    wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -O /usr/bin/jq && \
+    chmod +x /usr/bin/jq && \
     apt-get install -f && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-4.8 50 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50 && \
+    mkdir -p /opt/feedhenry/fh-dynoman/dynos/  && \
+    chmod -R 777 /opt/feedhenry/fh-dynoman/dynos/  && \
+    mkdir -p /opt/feedhenry/fh-dynoman/state/  && \
+    chmod -R 777 /opt/feedhenry/fh-dynoman/state/ && \
     mkdir -p /home/jenkins
 
 RUN echo default:x:1001:0:root:/home/jenkins:/bin/bash >> /etc/passwd


### PR DESCRIPTION
This is the part of the removing --ignore-scripts in our build-jobs.

The image is already updated on https://hub.docker.com/r/fhwendy/jenkins-slave-base-ubuntu/