### PR TITLE
Add Ansible slave

### DIFF
--- a/jenkins-template.yml
+++ b/jenkins-template.yml
@@ -66,7 +66,7 @@ objects:
     strategy:
       dockerStrategy:
           noCache: true
-          forcePull: true  
+          forcePull: true
       type: Docker
     triggers:
     - type: ImageChange
@@ -98,7 +98,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-          forcePull: true  
+          forcePull: true
           noCache: true
       type: Docker
     triggers:
@@ -131,7 +131,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-          forcePull: true  
+          forcePull: true
           noCache: true
       type: Docker
     triggers:
@@ -164,7 +164,7 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-          forcePull: true  
+          forcePull: true
           noCache: true
       type: Docker
     triggers:
@@ -196,6 +196,39 @@ objects:
       contextDir: slave-ruby-fhcap
       type: Git
     strategy:
+      type: Docker
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}-slave-ansible
+    annotations:
+        slave-label: ansible
+    labels:
+      role: jenkins-slave
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ${JENKINS_SERVICE_NAME}-slave-ansible
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${JENKINS_SERVICE_NAME}-slave-ansible:latest
+    runPolicy: Serial
+    source:
+      git:
+        uri: https://github.com/${GITHUB_ORG}/wendy-jenkins-s2i-configuration
+        ref: ${GITHUB_REF}
+      contextDir: slave-ansible
+      type: Git
+    strategy:
+      dockerStrategy:
+          forcePull: true
+          noCache: true
       type: Docker
     triggers:
     - type: ImageChange

--- a/slave-ansible/Dockerfile
+++ b/slave-ansible/Dockerfile
@@ -1,0 +1,10 @@
+FROM openshift/jenkins-slave-base-centos7
+
+MAINTAINER Oleg Matskiv <omatskiv@redhat.com>
+
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible

--- a/slave-ansible/cccp.yml
+++ b/slave-ansible/cccp.yml
@@ -1,0 +1,41 @@
+# This is for the purpose of building containers on the CentOS Community Container
+# Pipeline. The containers are built, tested and delivered to registry.centos.org and
+# lifecycled as well. A corresponding entry must exist in the container index itself,
+# located at https://github.com/CentOS/container-index/tree/master/index.d
+# You can know more at the following links:
+# * https://github.com/CentOS/container-pipeline-service/blob/master/README.md
+# * https://github.com/CentOS/container-index/blob/master/README.rst
+# * https://wiki.centos.org/ContainerPipeline
+
+# This will be part of the name of the container. It should match the job-id in index entry
+job-id: jenkins-slave-ansible-centos7
+
+#the following are optional, can be left blank
+#defaults, where applicable are filled in
+#nulecule-file   : nulecule
+
+# This flag tells the container pipeline to skip user defined tests on their container
+test-skip       : True
+
+# This is path of the script that initiates the user defined tests. It must be able to
+# return an exit code.
+test-script     : null
+
+# This is the path of custom build script.
+build-script    : null
+
+# This is the path of the custom delivery script
+delivery-script : null
+
+# This flag tells the pipeline to deliver this container to docker hub.
+docker-index    : True
+
+# This flag can be used to enable or disable the custom delivery
+custom-delivery : False
+
+# This flag can be used to enable or disable delivery of container to local registry
+local-delivery  : True
+
+Upstreams       :
+        - ref           :
+          url           :

--- a/slave-ansible/test/run
+++ b/slave-ansible/test/run
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+#
+# Test the Jenkins image.
+#
+# IMAGE_NAME specifies the name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+# make sure oc is installed
+docker run ${IMAGE_NAME} oc
+
+# make sure ansible commands are available
+docker run ${IMAGE_NAME} ansible --version
+docker run ${IMAGE_NAME} ansible-playbook --version
+
+echo "SUCCESS!"


### PR DESCRIPTION
**Why:** So we can use ansible plugin for jenkins, in particular its [pipelines support](https://github.com/jenkinsci/ansible-plugin#pipeline-support), e.g.:
```
node('ansible') {
    ansiblePlaybook( 
        playbook: 'path/to/playbook.yml',
        inventory: 'path/to/inventory.ini',
        extras: '-e parameter="some value"')
}
```

Dockerfile is based on official Dockerfile for Ansible - https://github.com/ansible/ansible-docker-base/blob/master/stable-centos7/Dockerfile

@psturc I believe you already did something similar, what was your approach ?

ping @AdamSaleh 