### PR TITLE
Added permissive-script-security plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -12,3 +12,4 @@ ssh-agent:1.13
 extended-choice-parameter:0.75
 rebuild:1.25
 ansicolor:0.5.0
+permissive-script-security:0.1


### PR DESCRIPTION
Added permissive-script-security plugin in order to avoid rhmap-release job failing and requiring in-script approval.

**Related JIRA:** https://issues.jboss.org/browse/RHMAP-13558

**Validation**

- Create a test image on Wendy
`s2i build /mnt/src/wendy-jenkins-s2i-configuration/ docker.io/fhwendy/jenkins-wendy-2-centos7 docker.io/fhwendy/jenkins-wendy-2-centos7:updated`
- Push the test image to docker hub
`docker push docker.io/fhwendy/jenkins-wendy-2-centos7:updated`
- Modify this line [this line](https://github.com/feedhenry/wendy-jenkins-s2i-configuration/blob/master/scripts/deploy_jenkins.sh#L45) to deploy jenkins from the test image created
`oc new-app -p ENABLE_OAUTH=false -p MEMORY_LIMIT=2Gi -p NAMESPACE=$PROJECT_NAME -p JENKINS_IMAGE_STREAM_TAG=jenkins:test -f  $TEMPLATES_DIR/jenkins-template.yml`
- Deploy Jenkins
`[vagrant@ose34 ~]$ PROJECT_NAME=wendy LIMITS=false /mnt/src/wendy-jenkins-s2i-configuration/scripts/deploy_jenkins.sh`
- Open the Jenkins UI and verify that the permissive-script-security plugin has been installed


