### PR TITLE
Installing AWS CLI in FHCAP Ruby Slave

### DIFF
--- a/slave-ruby-fhcap/Dockerfile
+++ b/slave-ruby-fhcap/Dockerfile
@@ -24,6 +24,8 @@ RUN yum groupinstall -y "Development Tools"
 
 RUN pip install python-novaclient
 
+RUN pip install awscli
+
 RUN scl enable rh-ruby23 "gem update --system"
 RUN scl enable rh-ruby23 "gem uninstall minitar"
 RUN scl enable rh-ruby23 "gem install minitar -v 0.5.4 -f"

--- a/slave-ruby-fhcap/test/run
+++ b/slave-ruby-fhcap/test/run
@@ -17,5 +17,6 @@ docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'ruby --version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'fhcap --version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'openssl version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'nova --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'aws --version'
 
 echo "SUCCESS!"


### PR DESCRIPTION
**Summary**
Adding AWS CLI python module to FHCAP Ruby Slave to support AWS Elastic File System

**Related Jira**
https://issues.jboss.org/browse/RHMAP-15137

**Validation**
Temporarily modify the GitHub Org and Ref in deploy script
_scripts/deploy_jenkins.sh_
```
export GH_ORG=pmccarthy
export GH_REF=RHMAP-15137_add_aws_cli
```
Deploy Jenkins with Builds enabled
```
$ PROJECT_NAME=wendy BUILD=true LIMITS=false ./scripts/deploy_jenkins.sh
```
Once Jenkins has been deployed a new fhcap ruby slave image should be available
```
[vagrant@ose34 ~]$ docker images
REPOSITORY                                                  TAG                 IMAGE ID            CREATED                  SIZE
172.30.24.212:5000/wendy/jenkins-slave-ruby-fhcap           latest              20dd2f636bd8        7 minutes ago            1.431 GB
```
Verify aws cli has been successfully installed
```
[vagrant@ose34 ~]$ docker run --rm --entrypoint=/bin/sh 172.30.24.212:5000/wendy/jenkins-slave-ruby-fhcap:latest -ic 'aws'
sh: cannot set terminal process group (-1): Inappropriate ioctl for device
sh: no job control in this shell
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: too few arguments
```