### PR TITLE
+ wget for ansible-slave

### DIFF
--- a/slave-ansible/Dockerfile
+++ b/slave-ansible/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Oleg Matskiv <omatskiv@redhat.com>
 USER root
 
 RUN yum clean all && \
+    yum -y install wget && \
     yum -y install epel-release && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip
 RUN mkdir /etc/ansible/


### PR DESCRIPTION
### Motivation
wget is mandatory for the scripts we're using to distribute images (osm4, osm1)