### PR TITLE
Add GitHub branch source plugin (github-branch-source:2.0.5)

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -14,3 +14,4 @@ rebuild:1.25
 ansicolor:0.5.0
 permissive-script-security:0.1
 swarm:3.4
+github-branch-source:2.0.5


### PR DESCRIPTION
Required by https://github.com/fheng/jenkins-bob-builder/pull/246