### PR TITLE
Ability to pass in GHREF and GHORG in env-vars

### DIFF
--- a/scripts/deploy_jenkins.sh
+++ b/scripts/deploy_jenkins.sh
@@ -1,6 +1,15 @@
 #!/bin/sh -xe
-export GH_ORG=feedhenry
-export GH_REF=master
+
+if [ -z "${GHORG}"]; then
+   GHORG=feedhenry
+fi
+
+if [ -z "${GHREF}"]; then
+   GHREF=master
+fi
+
+export GH_ORG=$GHORG
+export GH_REF=$GHREF
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEMPLATES_DIR="$( cd $SCRIPTS_DIR/../templates && pwd )"
@@ -45,7 +54,7 @@ if [ "$LIMITS" = true ] ; then
 fi
 
 if [ "$BUILD" = true ] ; then
-    oc new-app -f  $TEMPLATES_DIR/jenkins-build-template.yaml
+    oc new-app -p GITHUB_ORG=$GH_ORG -p GITHUB_REF=$GH_REF -f  $TEMPLATES_DIR/jenkins-build-template.yaml
 else
     oc new-app -f  $TEMPLATES_DIR/jenkins-image-template.yaml
 fi


### PR DESCRIPTION
Add ability to specify the gh ref and org with env-vars, as the rest of the params, i.e:
```
PROJECT_NAME=asaleh-try-gh0 BUILD=
true GHORG=adamsaleh GHREF=configurable_ghref /scripts/deploy_jenkins.sh
```