### PR TITLE
Add expect package to base slave image.

### DIFF
--- a/slave-base-centos7/Dockerfile
+++ b/slave-base-centos7/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/home/jenkins
 USER root
 # Install headless Java
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless java-1.8.0-openjdk-headless.i686 lsof rsync tar unzip which zip" && \
+    INSTALL_PKGS="bc expect gettext git java-1.8.0-openjdk-headless java-1.8.0-openjdk-headless.i686 lsof rsync tar unzip which zip" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/slave-base-ubuntu/Dockerfile
+++ b/slave-base-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \
     apt-get update && \
-    apt-get -y install gcc-4.8 make memcached ant bc curl wget gettext openjdk-8-jdk lsof unzip zip liblog4cxx10-dev bzip2 g++-4.8 && \
+    apt-get -y install gcc-4.8 make memcached ant bc curl wget gettext openjdk-8-jdk lsof unzip zip liblog4cxx10-dev bzip2 g++-4.8 expect && \
     wget http://ftp.us.debian.org/debian/pool/main/n/nss-wrapper/libnss-wrapper_1.1.3-1_amd64.deb && \
     dpkg -i libnss-wrapper_1.1.3-1_amd64.deb && \
     wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -O /usr/bin/jq && \
@@ -32,7 +32,7 @@ RUN apt-get -y install libcurl4-gnutls-dev git libexpat1-dev gettext libz-dev li
     wget https://www.kernel.org/pub/software/scm/git/git-1.8.5.6.tar.gz  && \
     tar -zxf git-1.8.5.6.tar.gz  && \
     cd git-1.8.5.6  &&  make prefix=/usr/local all && make prefix=/usr/local install && \
-    cd .. && rm -Rf git-* 
+    cd .. && rm -Rf git-*
 
 RUN echo default:x:1001:0:root:/home/jenkins:/bin/bash >> /etc/passwd
 


### PR DESCRIPTION
Adding expect[1] utility because it can be useful for automating interaction with SW over CLI.

I am using it for executing action once Ansible installer displays prompt. I can add it to just ansible slave, but I think this could have other applications as well.

[1] https://en.wikipedia.org/wiki/Expect