### PR TITLE
Updated inactive link for epel download

### DIFF
--- a/slave-ruby-fhcap/Dockerfile
+++ b/slave-ruby-fhcap/Dockerfile
@@ -10,7 +10,7 @@ ENV BASH_ENV=/usr/local/bin/scl_enable \
 
 COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 
 RUN yum -y update
 RUN yum -y install python-pip


### PR DESCRIPTION
While testing this new jenkins [job](https://issues.jboss.org/browse/RHMAP-15939) I noticed the ruby-fhcap slave build was failing, the cause being that the following [link](https://github.com/feedhenry/wendy-jenkins-s2i-configuration/blob/master/slave-ruby-fhcap/Dockerfile#L13) is no longer active.

I've changed it to an active link, run the [tests](https://github.com/feedhenry/wendy-jenkins-s2i-configuration/blob/master/slave-ruby-fhcap/test/run) and run a job (Cluster Destroy) that runs on that slave. All successful.

**Steps to Verify:**
Run tests on Docker image
- checkout this branch
- export IMAGE_NAME=test-slave-ruby-fhcap
- cd wendy-jenkins-s2i-configuration/slave-ruby-fhcap
- docker build -t $IMAGE_NAME .
- ./test/run

**Or**
Run a Jenkins Job on the image
- oc delete is jenkins-slave-ruby-fhcap
oc import-image jenkins-slave-ruby-fhcap:latest --from docker.io/fhwendy/jenkins-slave-ruby-fhcap:rshelly-test --confirm
- run a jenkins job that uses ruby-fhcap slave (e.g. Cluster Create/Destroy)


**Related JIRA:** Didn't log a ticket as it was a simple change.