### PR TITLE
Adding openshift-template-tool binary for RC pipeline template updates

### DIFF
--- a/slave-nodejs-ubuntu/Dockerfile
+++ b/slave-nodejs-ubuntu/Dockerfile
@@ -16,6 +16,9 @@ RUN mkdir -p /opt/feedhenry/fh-dynoman/dynos/  && \
     chmod -R 777 /opt/feedhenry/fh-dynoman/dynos/  && \
     chmod -R 777 /opt/feedhenry/fh-dynoman/state/
 
+RUN wget -q -O /usr/local/bin/openshift-template-tool https://github.com/feedhenry/openshift-template-tool/releases/download/0.0.2/openshift-template-tool-linux-amd64 && \
+    chmod 755 /usr/local/bin/openshift-template-tool
+
 USER default
 
 RUN export NVM_DIR="$HOME/.nvm" && \

--- a/slave-nodejs-ubuntu/test/run
+++ b/slave-nodejs-ubuntu/test/run
@@ -9,4 +9,5 @@
 docker run ${IMAGE_NAME} oc
 docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'npm --version'
 docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'node --version'
+docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'openshift-template-tool version'
 echo "SUCCESS!"


### PR DESCRIPTION
**Summary**
The purpose of this change is to add the openshift-template-tool binary to the nodejs-ubuntu slave so that we can execute https://github.com/fheng/fh-core-openshift-templates/blob/master/scripts/update-generated-templates as part of the configuration update stage of the RC Jenkins pipeline

**Related Jira**
https://issues.jboss.org/browse/RHMAP-15775

**Validation**
```
$ docker build -t fhwendy/jenkins-slave-nodejs-ubuntu slave-nodejs-ubuntu/
$ docker run -i -t fhwendy/jenkins-slave-nodejs-ubuntu:test /bin/bash
builder@fc2fa4123af8:/$ openshift-template-tool version
Version: 0.0.2
Commit: ff2716b
```
