### PR TITLE
Adding openshift-template-tool to nodejs6-ubuntu slave

### DIFF
--- a/slave-nodejs6-ubuntu/Dockerfile
+++ b/slave-nodejs6-ubuntu/Dockerfile
@@ -2,6 +2,11 @@ FROM docker.io/fhwendy/jenkins-slave-nodejs-ubuntu:latest
 
 MAINTAINER Adam Saleh <asaleh@redhat.com>
 
+USER root
+
+RUN wget -q -O /usr/local/bin/openshift-template-tool https://github.com/feedhenry/openshift-template-tool/releases/download/0.0.2/openshift-template-tool-linux-amd64 && \
+    chmod 755 /usr/local/bin/openshift-template-tool
+
 USER default
 
 RUN export NVM_DIR="$HOME/.nvm" && \

--- a/slave-nodejs6-ubuntu/test/run
+++ b/slave-nodejs6-ubuntu/test/run
@@ -9,4 +9,5 @@
 docker run ${IMAGE_NAME} oc
 docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'npm --version'
 docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'node --version'
+docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'openshift-template-tool version'
 echo "SUCCESS!"


### PR DESCRIPTION
**Summary**
Adding openshift-template-tool to nodejs6-ubuntu slave

**Validation**
```
$ docker build -t fhwendy/jenkins-slave-nodejs6-ubuntu:test .
$ docker run -i -t fhwendy/jenkins-slave-nodejs6-ubuntu:test /bin/bash
builder@9de2b4774818:/$ openshift-template-tool
Command line tool for working with OpenShift templates

Usage:
  openshift-template-tool [command]

Available Commands:
  merge       Merge OpenShift templates
  version     Display version

Flags:
      --debug[=false]: Output debug information.
  -h, --help[=false]: help for openshift-template-tool

Use "openshift-template-tool [command] --help" for more information about a command.
```