### PR TITLE
🐛 Follow redirect when downloading template tool

### DIFF
--- a/slave-nodejs6-centos7/Dockerfile
+++ b/slave-nodejs6-centos7/Dockerfile
@@ -19,6 +19,6 @@ USER 1001
 
 RUN echo "prefix=${HOME}" > ${HOME}/.npmrc && \
     scl enable rh-nodejs6 "npm i -g grunt jira-miner" && \
-    curl -o ${HOME}/bin/openshift-template-tool https://github.com/feedhenry/openshift-template-tool/releases/download/0.0.2/openshift-template-tool-linux-amd64 && \
+    curl -Lo ${HOME}/bin/openshift-template-tool https://github.com/feedhenry/openshift-template-tool/releases/download/0.0.2/openshift-template-tool-linux-amd64 && \
     chmod 755 ${HOME}/bin/openshift-template-tool && \
     chmod -R 775 ${HOME}/lib ${HOME}/etc ${HOME}/bin ${HOME}/.npm ${HOME}/.npmrc

--- a/slave-nodejs6-centos7/test/run
+++ b/slave-nodejs6-centos7/test/run
@@ -10,5 +10,6 @@ docker run --rm -t --entrypoint=/bin/bash ${IMAGE_NAME} -ic 'source /usr/local/b
 docker run --rm -t --entrypoint=/bin/bash ${IMAGE_NAME} -ic 'source /usr/local/bin/configure-slave && git --version'
 docker run --rm -t --entrypoint=/bin/bash ${IMAGE_NAME} -ic 'source /usr/local/bin/configure-slave && npm --version'
 docker run --rm -t --entrypoint=/bin/bash ${IMAGE_NAME} -ic 'source /usr/local/bin/configure-slave && node --version'
+docker run --rm -t --entrypoint=/bin/bash ${IMAGE_NAME} -ic 'source /usr/local/bin/configure-slave && openshift-template-tool version'
 
 echo "SUCCESS!"


### PR DESCRIPTION
Without this change, the openshift-template-tool is just a short html file containing info on the the redirect.