### PR TITLE
oc v3.7 in centos image

### DIFF
--- a/slave-base-centos7/Dockerfile
+++ b/slave-base-centos7/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y centos-release-scl-rh && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    set -o pipefail && curl -L https://github.com/openshift/origin/releases/download/v1.5.0/openshift-origin-client-tools-v1.5.0-031cbe4-linux-64bit.tar.gz | \
+    set -o pipefail && curl -L https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit.tar.gz | \
     tar -zx && \
     mv openshift*/oc /usr/local/bin && \
     rm -rf openshift-origin-client-tools-* && \


### PR DESCRIPTION
### Motivation
[oc.policy() command](https://github.com/openshift/jenkins-client-plugin/blob/master/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy#L764) did not work with v1.5.0 client when targeting v3.7.0 cluster.
```
oc policy add-role-to-user edit -z default
Error from server (NotFound): the server could not find the requested resource
```