### PR TITLE
🐛 Add jdk-tool plugin to satisfy a NoClassDefFoundError

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -12,6 +12,7 @@ extended-choice-parameter:0.76
 github-api:1.92
 github-branch-source:2.3.6
 http_request:1.8.22
+jdk-tool:1.1
 jobConfigHistory:2.18
 lockable-resources:2.3
 maven-plugin:3.1.2


### PR DESCRIPTION
- Error is seen at startup
- Functionality was split from core to plugin in 2.112